### PR TITLE
Multi account manager

### DIFF
--- a/samples/api_multiple_accounts.py
+++ b/samples/api_multiple_accounts.py
@@ -1,36 +1,35 @@
 from td.client import TDClient
 from td.AccountsManager import AccountsManager
-import Extensions.file_utils as file_utils
-import json
-import os
+
+#-----------set up accounts programatically-------------------------
 
 Accounts = AccountsManager("***client_id****", '***redirect_uri***')
 
-Accounts.add_account('name of an account', '### account ###', '***credentials_path***')
-Accounts.add_account('2', '### account ###', '***credentials_path***')
+Accounts.add_account('My IRA', '### account ###', '***credentials_path***')
+Accounts.add_account('Dads IRA', '### account ###', '***credentials_path***')
 #...
 
 Accounts.login() #logs in all accounts
 
-Accounts.print_account_worths() #prints liquidation values of all accounts -- just handy, arguably moved/removed
+#prints liquidation values of all accounts -- just handy, arguably could be moved|removed
+Accounts.print_account_worths() 
 
-#save:
-file_utils.save_json('../Accounts.json', Accounts.to_dict()) 
+#Save by any user chosen means (with possible helpers to be included in td.utils):
+Accounts.to_dict()
 
 Accounts.logout()
 
+#-----------------------------Load from anything-----------------------
+accounts_dict = #pull from something, eg with json.load
 
-#load:
-accounts_dict = file_utils.load_json('../Accounts.json')
-if len(accounts_dict) == 0:
-    print('Found no accounts logged in!')
-    pass
+#initialize once source is known good:
 Accounts = AccountsManager.from_dict(accounts_dict)
 
+#repeat:
 Accounts.login()
 
 Accounts.print_account_worths()
 
 
 
-TDSession = Accounts['My IRA']
+current_session = Accounts['My IRA']

--- a/samples/api_multiple_accounts.py
+++ b/samples/api_multiple_accounts.py
@@ -1,0 +1,36 @@
+from td.client import TDClient
+from td.AccountsManager import AccountsManager
+import Extensions.file_utils as file_utils
+import json
+import os
+
+Accounts = AccountsManager("***client_id****", '***redirect_uri***')
+
+Accounts.add_account('name of an account', '### account ###', '***credentials_path***')
+Accounts.add_account('2', '### account ###', '***credentials_path***')
+#...
+
+Accounts.login() #logs in all accounts
+
+Accounts.print_account_worths() #prints liquidation values of all accounts -- just handy, arguably moved/removed
+
+#save:
+file_utils.save_json('../Accounts.json', Accounts.to_dict()) 
+
+Accounts.logout()
+
+
+#load:
+accounts_dict = file_utils.load_json('../Accounts.json')
+if len(accounts_dict) == 0:
+    print('Found no accounts logged in!')
+    pass
+Accounts = AccountsManager.from_dict(accounts_dict)
+
+Accounts.login()
+
+Accounts.print_account_worths()
+
+
+
+TDSession = Accounts['My IRA']

--- a/td/accounts_manager.py
+++ b/td/accounts_manager.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+from td.client import TDClient
+
+class AccountsManager():
+    accounts = {}
+    
+    def __init__(self, client_id: str, redirect_uri: str) -> None:
+        self.client_id = client_id
+        self.redirect_uri = redirect_uri
+        self._should_be_logged_in = False
+
+    @classmethod
+    def from_dict(cls, d: dict) -> AccountsManager:
+        am = cls(d['client_id'], d['redirect_uri'])
+        for account in d['accounts'].items():
+            am.add_account(account[0], account[1]['account_number'], account[1]['credentials_path'])
+        return am
+
+    def to_dict(self) -> dict:
+        return {
+            'client_id':self.client_id,
+            'redirect_uri':self.redirect_uri,
+            'accounts':{a[0]:{b[0]:b[1] for b in a[1].items() if b[0] != 'client'} for a in self.accounts.items()}
+        }
+
+    def print_account_worths(self) -> None:
+        for account in self.accounts.items():
+            client = account[1].get('client')
+            if client is not None:
+                accInfo = client.get_accounts(fields = ['orders','positions'])
+                if accInfo is None or 'error' in accInfo:
+                    print('Error, get_accounts returned: ',print(json.dumps(accInfo,sort_keys=True, indent=4)))
+                else:
+                    for acc in [acc['securitiesAccount'] for acc in accInfo]:
+                        if acc['accountId'] == account[1]['account_number']:
+                            print(str.format('{} (#{}) Liquidation Value = {}',account[0],acc['accountId'], acc['currentBalances']['liquidationValue']))
+        
+    def add_account(self, key: str, accountNumber: str, accountPath: str=None) -> None:
+        self.accounts[key] = {'account_number':accountNumber, 'credentials_path':accountPath, 'client':None}
+
+        if self._should_be_logged_in:
+            self.login_single(key=key, should_relogin=False)
+    
+    def login(self, should_relogin: bool=True) -> None:
+        if should_relogin or not self._should_be_logged_in:
+            for acc in self.accounts.keys():
+                self.login_single(acc, should_relogin=self._should_be_logged_in)
+        self._should_be_logged_in = True
+    
+    def login_single(self, key: str, should_relogin: bool=True) -> None:
+        account = self.accounts.get(key)
+        if account is None:
+            raise KeyError("The passed key is not registered with this AccountManager; Please add_account(...) first!")
+        client = account['client']
+        
+        if should_relogin and client is not None:
+            client.logout()
+        
+        print('Logging in: ',key)
+        
+        client = TDClient(
+            account_number = account['account_number'],
+            client_id = self.client_id, redirect_uri = self.redirect_uri,
+            credentials_path = account['credentials_path'])
+        client.login()
+        account['client'] = client
+        client.client_key = key
+        
+    def logout(self) -> None:
+        for account in self.accounts.values():
+            client = account['client']
+            if client is not None:
+                client.logout()
+                account['client'] = None
+
+        self._should_be_logged_in = False
+
+    def __getitem__(self, key: str) -> TDClient:
+        return self.accounts[key]['client']
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
Just a thought if you want it. -- Could be useful, could easily be out of scope.

I can add doc strings first if you want, wanted thoughts first.


I added this on my end to more easily handle my, and my family's, accounts without having to worry about accidentally pushing credentials, getting them confused, or relying on hard coded paths or home directory defaults (running in a vm, so all has to go to a shared folder).

Was thinking with this though, it could be nice to have a minimized serialize function in client to only pull what is needed for login in addition to what is already in accounts_manager's file, so they can all get wrapped together. -- Possibly leaving whats in client still intact by default, but then providing greater capability to save in a user chosen way.