### PR TITLE
fix fetching historical data using period and frequency

### DIFF
--- a/td/client.py
+++ b/td/client.py
@@ -748,7 +748,7 @@ class TDClient():
             try:
 
                 # check if the period is valid.
-                if period in VALID_CHART_VALUES[frequency_type][int(period_type)]:
+                if int(period) in VALID_CHART_VALUES[frequency_type][period_type]:
                     True
                 else:
                     raise IndexError('Invalid Period.')


### PR DESCRIPTION
I was trying to grab historical info via period and frequency and nothing I did was working. So I dug into the code a bit and how it works with the definitions of VALID_CHART_VALUES and noticed we needed a change. you were checking to see if period (defined as string in params) existed in the final array which is actually comprised of ints in the definition of VALID_CHART_VALUES. Also, you were converting period_type to an int, when it needed to be a string in the definition of VALID_CHART_TYPES. Changed these and was able to pull data. Hope this helps!