### PR TITLE
make_request fix

### DIFF
--- a/td/client.py
+++ b/td/client.py
@@ -405,15 +405,14 @@ class TDClient():
 
         # save the access token and refresh token
         self.state['access_token'] = token_dict['access_token']
-        self.state['refresh_token'] = token_dict['refresh_token']
-
-        # store token expiration time
         access_token_expire = time.time() + int(token_dict['expires_in'])
-        refresh_token_expire = time.time() + int(token_dict['refresh_token_expires_in'])
         self.state['access_token_expires_at'] = access_token_expire
-        self.state['refresh_token_expires_at'] = refresh_token_expire
         self.state['access_token_expires_at_date'] = datetime.datetime.fromtimestamp(access_token_expire).isoformat()
-        self.state['refresh_token_expires_at_date'] = datetime.datetime.fromtimestamp(refresh_token_expire).isoformat()
+        if 'refresh_token' in token_dict:
+            self.state['refresh_token'] = token_dict['refresh_token']
+            refresh_token_expire = time.time() + int(token_dict['refresh_token_expires_in'])
+            self.state['refresh_token_expires_at'] = refresh_token_expire
+            self.state['refresh_token_expires_at_date'] = datetime.datetime.fromtimestamp(refresh_token_expire).isoformat()
         self.state['logged_in'] = True
 
         self._state_manager('save')

--- a/td/client.py
+++ b/td/client.py
@@ -341,7 +341,6 @@ class TDClient():
         data = {
             'client_id': self.client_id,
             'grant_type': 'refresh_token',
-            'access_type': 'offline',
             'refresh_token': self.state['refresh_token']
         }
 
@@ -507,12 +506,12 @@ class TDClient():
         """
 
         url = self._api_endpoint(endpoint=endpoint)
-        headers = self._headers(mode=mode)
 
         # Make sure the token is valid if it's not a Token API call.
         if endpoint != self.config['token_endpoint']:
             self._token_validation()
-        elif endpoint == self.config['token_endpoint']:
+        headers = self._headers(mode=mode)
+        if endpoint == self.config['token_endpoint']:
             del headers['Authorization']
 
         # Define a new session.


### PR DESCRIPTION
According to https://developer.tdameritrade.com/authentication/apis/post/token-0 "Do not set to offline on a refresh_token grant type request."  Also if token is refreshed during _token_validation then headers should be assigned after it is refreshed otherwise the expired token will be included in headers