### PR TITLE
The check needs to be performed on the period that is if the period i…

### DIFF
--- a/td/client.py
+++ b/td/client.py
@@ -748,7 +748,7 @@ class TDClient():
             try:
 
                 # check if the period is valid.
-                if period in VALID_CHART_VALUES[frequency_type][int(period_type)]:
+                if int(period) in VALID_CHART_VALUES[frequency_type][period_type]:
                     True
                 else:
                     raise IndexError('Invalid Period.')


### PR DESCRIPTION
The check needs to be performed on the period that is if the period is in the VALID_CHART_VALUES dictionary.
As is raises error when not end_date is not specified example: session.get_price_history(symbol='XOM', period_type='month', period='1', frequency_type='daily',frequency='1') would raise error.