### PR TITLE
Create directories before saving credentials

### DIFF
--- a/td/client.py
+++ b/td/client.py
@@ -219,7 +219,15 @@ class TDClient():
                 self.state.update(json.load(json_file))
 
         # if they want to save it and have allowed for caching then load the file.
-        elif action == 'save':     
+        elif action == 'save':
+            # Create parent directory if it doesn't exist
+            if not credentials_file_exists:
+                try:
+                    os.makedirs(os.path.dirname(self.credentials_path))
+                except OSError as exc: # Guard against race condition
+                    if exc.errno != errno.EEXIST:
+                        raise
+            # Save file
             with open(file=self.credentials_path, mode='w+') as json_file:
                 json.dump(obj=self.state, fp=json_file, indent=4)
 


### PR DESCRIPTION
This will prevent a FileNotFound error when the user first run the authentication process without creating the directory structure.